### PR TITLE
Create temp directory

### DIFF
--- a/fontpreview
+++ b/fontpreview
@@ -6,9 +6,10 @@
 
 # Use mktemp to create temporary files that won't
 # collide with any other application's tmp files.
-PIDFILE="$(mktemp --tmpdir fontpreview_XXXXXXXX.pid)"
-FONT_PREVIEW="$(mktemp --tmpdir fontpreview_XXXXXXXX.png)"
-TERMWIN_IDFILE="$(mktemp --tmpdir fontpreview_XXXXXXXX.termpid)"
+FONTPREVIEW_DIR="$(mktemp -d --tmpdir fontpreview_dir_XXXXXXXX)"
+PIDFILE="$(mktemp --tmpdir="$FONTPREVIEW_DIR" fontpreview_XXXXXXXX.pid)"
+FONT_PREVIEW="$(mktemp --tmpdir="$FONTPREVIEW_DIR" fontpreview_XXXXXXXX.png)"
+TERMWIN_IDFILE="$(mktemp --tmpdir="$FONTPREVIEW_DIR" fontpreview_XXXXXXXX.termpid)"
 VERSION=1.0.0
 
 # Default values


### PR DESCRIPTION
to contain fontpreview temp files.

Note: this is absolutely optional PR. 

I did it for testing purpose: `/tmp` quickly gets filled with old files.
Now it is way easier to clean everything up during tests and even when exiting `fontpreview`.

Automatic clean not yet implemented.