### PR TITLE
Create directories on install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,12 @@ all:
 	@echo Run \'make install\' to install fontpreview on your device
 
 install:
+	@mkdir -p $(DESTDIR)$(BINDIR)
 	@cp fontpreview $(DESTDIR)$(BINDIR)/fontpreview
 	@chmod 755 $(DESTDIR)$(BINDIR)/fontpreview
 	@echo fontpreview has been installed on your device
 
 uninstall:
 	@rm -rf $(DESTDIR)$(BINDIR)/fontpreview
+	@rmdir -p --ignore-fail-on-non-empty $(DESTDIR)$(BINDIR)
 	@echo fontpreview has been removed from your device


### PR DESCRIPTION
`$(DESTDIR)$(BINDIR)` may not exist.

I ran into this while making an ebuild for Gentoo. The package is first installed into a clean `DESTDIR` before it is copied to the system.